### PR TITLE
fix: scheduling tag retrieval

### DIFF
--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -208,15 +208,15 @@ def deploy(  # noqa: C901
         parameter_values, input_artifacts = load_config(config_filepath)
 
     if compile:
-        with console.status("Compiling pipeline...\n"):
+        with console.status("Compiling pipeline..."):
             deployer.compile()
 
     if upload:
-        with console.status("Uploading pipeline...\n"):
+        with console.status("Uploading pipeline..."):
             deployer.upload_to_registry(tags=tags)
 
     if run:
-        with console.status("Running pipeline...\n"):
+        with console.status("Running pipeline..."):
             deployer.run(
                 enable_caching=enable_caching,
                 parameter_values=parameter_values,
@@ -226,7 +226,7 @@ def deploy(  # noqa: C901
             )
 
     if schedule:
-        with console.status("Scheduling pipeline...\n"):
+        with console.status("Scheduling pipeline..."):
             cron = cron.replace("-", " ")  # ugly fix to allow cron expression as env variable
             deployer.schedule(
                 cron=cron,

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -256,13 +256,14 @@ class VertexPipelineDeployer:
 
         if tag:
             client = RegistryClient(host=self.gar_host)
+            package_name = self.pipeline_name.replace("_", "-")
             try:
-                tag_metadata = client.get_tag(package_name=self.pipeline_name, tag=tag)
+                tag_metadata = client.get_tag(package_name=package_name, tag=tag)
             except HTTPError as e:
-                tags_list = client.list_tags(self.pipeline_name)
+                tags_list = client.list_tags(package_name)
                 tags_list_parsed = [x["name"].split("/")[-1] for x in tags_list]
                 raise TagNotFoundError(
-                    f"Tag {tag} not found for package {self.gar_host}/{self.pipeline_name}.\
+                    f"Tag {tag} not found for package {self.gar_host}/{package_name}.\
                         Available tags: {tags_list_parsed}"
                 ) from e
 


### PR DESCRIPTION
## Description

Scheduling was broken because of a tag retrieval issue in artifact registry.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
