### PR TITLE
docs: fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ export GCP_REGION=<your_gcp_region>
 export VERTEX_STAGING_BUCKET_NAME=<your_bucket_name>
 gcloud storage buckets create gs://${VERTEX_STAGING_BUCKET_NAME} --location=${GCP_REGION}
 ```
-7. Create a service account for Vertex Pipelines: # TODO: complete iam bindings
+7. Create a service account for Vertex Pipelines:
 ```bash
 export VERTEX_SERVICE_ACCOUNT_NAME=foobar
 export VERTEX_SERVICE_ACCOUNT="${VERTEX_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
@@ -193,7 +193,7 @@ vertex
 ```
 
 > [!NOTE]
-> You must have at lease these files. If you need to share some config elements between pipelines,
+> You must have at least these files. If you need to share some config elements between pipelines,
 > you can have a `shared` folder in `configs` and import them in your pipeline configs.
 
 #### Pipelines
@@ -221,7 +221,7 @@ def pipeline():
 Config file can be either `.py`, `.json` or `.toml` files.
 They must be located in the `config/{pipeline_name}` folder.
 
-**Why two formats?**
+**Why three formats?**
 
 `.py` files are useful to define complex configs (e.g. a list of dicts) while `.json` / `.toml` files are useful to define simple configs (e.g. a string).
 
@@ -269,7 +269,7 @@ vertex-deployer deploy dummy_pipeline \
     --env-file example.env \
     --local-package-path . \
     --tags my-tag \
-    --parameter-values-filepath vertex/configs/dummy_pipeline/config_test.json \
+    --config-filepath vertex/configs/dummy_pipeline/config_test.json \
     --experiment-name my-experiment \
     --enable-caching
 ```
@@ -279,7 +279,7 @@ vertex-deployer deploy dummy_pipeline \
 To check that your pipelines are valid, you can use the `check` command. It uses a pydantic model to:
 - check that your pipeline imports and definition are valid
 - check that your pipeline can be compiled
-- generate a pydantic model from the pipeline parameters definition and check that all configs related to the pipeline are valid
+- check that all configs related to the pipeline are respecting the pipeline definition (using a Pydantic model based on pipeline signature)
 
 To validate one specific pipeline:
 ```bash


### PR DESCRIPTION
## Description

Fix multiple typos in README.md

The changes include corrections in the section titles, command descriptions, and the explanation of the tool's use cases

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
