### PR TITLE
fix: add pipeline root path check in create command

### DIFF
--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -368,6 +368,13 @@ def create(
     """Create files structure for a new pipeline."""
     logger.info(f"Creating pipeline {pipeline_name}")
 
+    if not Path(PIPELINE_ROOT_PATH).is_dir():
+        raise FileNotFoundError(
+            f"Pipeline root path '{PIPELINE_ROOT_PATH}' does not exist."
+            " Please check that the pipeline root path is correct"
+            f" or create it with `mkdir -p {PIPELINE_ROOT_PATH}`."
+        )
+
     pipeline_filepath = Path(PIPELINE_ROOT_PATH) / f"{pipeline_name}.py"
     pipeline_filepath.touch(exist_ok=False)
     pipeline_filepath.write_text(PIPELINE_MINIMAL_TEMPLATE.format(pipeline_name=pipeline_name))


### PR DESCRIPTION
## Description

introduces a check to ensure the `PIPELINE_ROOT_PATH` exists before attempting to create a new pipeline. If the path does not exist, a `FileNotFoundError` is raised with a message suggesting how to create the path.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
