### PR TITLE
fix: base unsupported config file error msg on config types enum

### DIFF
--- a/deployer/utils/config.py
+++ b/deployer/utils/config.py
@@ -96,8 +96,8 @@ def load_config(config_filepath: Path) -> Tuple[Optional[dict], Optional[dict]]:
         return parameter_values, input_artifacts
 
     raise UnsupportedConfigFileError(
-        f"{config_filepath}: Config file type {config_filepath.suffix} is not supported."
-        " Please use a JSON or Python file."
+        f"{config_filepath}: Config file extension '{config_filepath.suffix}' is not supported."
+        f" Supported config file types are: {', '.join(ConfigType.__members__.values())}"
     )
 
 


### PR DESCRIPTION
## Description

`UnsupportedConfigFileError` was raised with outdated message (toml not mentionned in supported config files). Base the error message on the enum with all config types.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
