### PR TITLE
fix: rm protected namespaces from pipeline model

### DIFF
--- a/deployer/utils/models.py
+++ b/deployer/utils/models.py
@@ -12,7 +12,9 @@ class CustomBaseModel(BaseModel):
 
     # FIXME: arbitrary_types_allowed is a workaround to allow to pass
     #        Vertex Pipelines Artifacts as parameters to a pipeline.
-    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        extra="forbid", arbitrary_types_allowed=True, protected_namespaces=()
+    )
 
 
 def _convert_artifact_type_to_str(annotation: type) -> type:


### PR DESCRIPTION
## Description

Remove protected namespace default value `model_` from `CustomBaseModel`

## Related Issue

Executing command `check` with a config with parameter values keys starting by `model_` was raising a warning because of [Pydantic default protected namespace](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces):
```bash
  warnings.warn(
/Users/jules.bertrand/miniconda3/envs/eduscore/lib/python3.10/site-packages/pydantic/_internal/_fields.py:127: UserWarning: Field "model_path" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
```

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
