### PR TITLE
fix: run option fails when not uploading to gar

### DIFF
--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -3,7 +3,7 @@ CONFIG_ROOT_PATH = "vertex/configs"
 
 DEFAULT_SCHEDULER_TIMEZONE = "Europe/Paris"
 DEFAULT_LOCAL_PACKAGE_PATH = "vertex/pipelines/compiled_pipelines"
-DEFAULT_TAGS = ["latest"]
+DEFAULT_TAGS = None
 
 TEMP_LOCAL_PACKAGE_PATH = ".vertex-deployer-temp"
 

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -78,11 +78,11 @@ class VertexPipelineDeployer:
         local package.
         """
         if self.gar_host is not None:
-            if tag:
-                return os.path.join(self.gar_host, self.pipeline_name.replace("_", "-"), tag)
-
             if self.template_name is not None and self.version_name is not None:
                 return os.path.join(self.gar_host, self.template_name, self.version_name)
+
+            if tag:
+                return os.path.join(self.gar_host, self.pipeline_name.replace("_", "-"), tag)
 
             logger.warning(
                 "tag or template_name and version_name not provided."
@@ -198,7 +198,7 @@ class VertexPipelineDeployer:
         enable_caching: bool = False,
         parameter_values: Optional[dict] = None,
         experiment_name: Optional[str] = None,
-        tags: List[str] = ["latest"],  # noqa: B006
+        tags: Optional[List[str]] = None,
     ) -> VertexPipelineDeployer:
         """Compile, upload and run pipeline on Vertex AI Pipelines"""
         self.compile()


### PR DESCRIPTION
## Description

Default tag was forcing to retrieve compiled pipeline from tagged Artifact Registry pipelines. Set default tag to None solves it.

## Related Issue

#84

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
