### PR TITLE
ci: upload to gar only if release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
         github_token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
 
     - name: 'Authenticate to Google Cloud'
+      if: steps.python-semantic-release.outputs.release == true
       uses: 'google-github-actions/auth@v1'
       with:
         token_format: 'access_token'
@@ -55,9 +56,11 @@ jobs:
         service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}' # e.g. - my-service-account@my-project.iam.gserviceaccount.com
 
     - name: Install twine
+      if: steps.python-semantic-release.outputs.release == true
       run: pip install twine keyrings.google-artifactregistry-auth
 
     - name: Upload dist to Google Artifact Registry
+      if: steps.python-semantic-release.outputs.release == true
       run: |
         python3 -m twine upload \
           --repository-url https://europe-west1-python.pkg.dev/vertex-deployer-sandbox-3a8a/vertex-deployer \


### PR DESCRIPTION
## Description

When a release is not made, CD fails because it tries to upload to Google Artifact Registry from the unexisting `dist/` folder. This PR adds a condition to upload only if a release was made by Python Semantic Release

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
