### PR TITLE
fix: inspect value empty for defaults in check cmd

### DIFF
--- a/deployer/utils/models.py
+++ b/deployer/utils/models.py
@@ -1,4 +1,4 @@
-from inspect import _empty, signature
+from inspect import Parameter, signature
 from typing import Callable, Literal, Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict, create_model
@@ -47,7 +47,7 @@ def create_model_from_func(
     func_typing = {
         p.name: (
             type_converter(p.annotation),
-            ... if (exclude_defaults or p.default == _empty) else p.default,
+            ... if (exclude_defaults or p.default == Parameter.empty) else p.default,
         )
         for p in func_signature.parameters.values()
     }


### PR DESCRIPTION
## **User description**

- Fixed an issue where default values in function signatures were not correctly handled when creating a Pydantic model from a function.
- The _empty value from the inspect module is now used to determine if a default value should be excluded.
- The create_model_from_func function has been refactored to improve the handling of default values.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.


___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where default values in function signatures were not correctly handled when creating a Pydantic model from a function.
- The `_empty` value from the `inspect` module is now used to determine if a default value should be excluded.
- The `create_model_from_func` function has been refactored to improve the handling of default values.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Handle Empty Default Values in Function Signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployer/utils/models.py
<li>Import <code>_empty</code> from <code>inspect</code> module.<br> <li> Refactor the creation of <code>func_typing</code> dictionary to handle default <br>values correctly.<br> <li> Update the <code>create_model</code> call to use the new <code>func_typing</code> dictionary.<br>


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/159/files#diff-3f902acf6777c642c7a3bbd911cff56723b4953b58c8824fc01c4958357e9a27">+10/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

