### PR TITLE
fix: instanciate list only if not ixisting when paring errors

### DIFF
--- a/deployer/utils/utils.py
+++ b/deployer/utils/utils.py
@@ -316,8 +316,7 @@ def _parse_validation_errors(
         else:
             config_name = error["loc"][3]
             error_row = {"type": error["type"], "msg": error["msg"]}
-            if config_name not in parsed_errors[pipeline_name].keys():
-                parsed_errors[pipeline_name][config_name] = []
+            parsed_errors[pipeline_name].setdefault(config_name, [])
             if len(error["loc"]) > 4:
                 error_row["field"] = error["loc"][5]
             parsed_errors[pipeline_name][config_name].append(error_row)


### PR DESCRIPTION
## **User description**
## Description

- Fixed a bug in _parse_validation_errors function where a new list for errors was being instantiated every time, even if it already existed.
- The error list is now only created if it does not exist for the specific configuration name within a pipeline.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.


___

## **Type**
bug_fix


___

## **Description**
- Fixed a bug in `_parse_validation_errors` function where a new list for errors was being instantiated every time, even if it already existed.
- The error list is now only created if it does not exist for the specific configuration name within a pipeline.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Fix Error Parsing Logic in Utility Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployer/utils/utils.py
<li>Ensure error list is only instantiated if it does not already exist <br>when parsing errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/161/files#diff-c854a0accdddf79ab2efae8606304be2f0c3f4b5f8ff03187494b4c7518f3de4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

