### PR TITLE
chore: create .skaff/skaff.yaml

### DIFF
--- a/.skaff/skaff.yaml
+++ b/.skaff/skaff.yaml
@@ -1,0 +1,28 @@
+spec_version: 1
+
+# Everyting in this file will be used to populate the catalog on skaff.artefact.com
+# It is also vectorized as is for the search, so make sure to provide relevant keywords
+
+name: Vertex Pipelines Deployer
+owner: jules.bertrand@artefact.com
+description: >
+  Check, compile, upload, run and schedule Vertex Pipelines in a standardized manner.
+documentation_url: https://supreme-funicular-mzylwj5.pages.github.io/
+
+type: deployable   # deployable, knowldege pack
+lifecycle: production  # prototype, production
+
+users:                 # DS, DA, DE
+  - DS
+  - DE
+
+clouds:                # aws, gcp, azure, databricks
+  - gcp
+
+technologies:          # python, dbt, terraform, airbyte, ...
+  - vertex
+  - python
+
+expertises:            # MMM, forecasting, ELT, release engineering, ...
+  - MLEng
+  - MLOps


### PR DESCRIPTION
Hey,

On va bouger de roadie pour le catalogue, donc je t'ajoute ce remplacement du `catalog-info.yaml`. Je laisse ce dernier le temps de la migration, il sera supprimé une fois roadie définitivement déprécié.
Une migration du repo vers l'org GitHub `artefactory-skaff` sera effectuée à ce moment là.

Pour info, le nouveau catalogue est à skaff.artefact.com.

Thanks !