### PR TITLE
improvement: add tests init

### DIFF
--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 TEMPLATES_PATH = Path(__file__).parent / "_templates"
+TEMPLATES_PATH_TESTS = Path("tests/unit_tests/input_files")
 
 DEFAULT_VERTEX_FOLDER_PATH = "vertex"
 DEFAULT_LOG_LEVEL = "INFO"

--- a/tests/integration_tests/test_init.py
+++ b/tests/integration_tests/test_init.py
@@ -1,0 +1,93 @@
+import tempfile
+from pathlib import Path
+
+import toml
+from typer.testing import CliRunner
+
+from deployer.cli import app
+
+runner = CliRunner()
+
+
+def test_init_command_with_defaults():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Change the current working directory to the temporary directory
+        with runner.isolated_filesystem(temp_dir=tmp_dir):
+            # Given
+            result = runner.invoke(app, ["init", "--default"])
+
+            # Then
+            assert result.exit_code == 0
+            assert "Default initialization done" in result.stdout
+            assert Path("vertex").is_dir()
+            assert (Path("vertex") / "pipelines" / "dummy_pipeline.py").is_file()
+            assert (Path("vertex") / "configs" / "dummy_pipeline" / "test.py").is_file()
+            assert (Path("vertex") / "configs" / "dummy_pipeline" / "dev.py").is_file()
+            assert (Path("vertex") / "configs" / "dummy_pipeline" / "prod.py").is_file()
+            assert (Path("vertex") / "deployment" / "cloudbuild_local.yaml").is_file()
+            assert (Path("vertex") / "deployment" / "Dockerfile").is_file()
+            assert (Path("vertex") / "deployment" / "build_base_image.sh").is_file()
+            assert (Path("vertex") / "lib").is_dir()
+            assert (Path("vertex") / "components").is_dir()
+            assert (Path("vertex") / "components" / "dummy_component.py").is_file()
+            assert Path("pyproject.toml").is_file()
+            assert not Path("pyproject.toml").read_text()
+            assert Path("deployer.env").is_file()
+            assert Path("requirements-vertex.txt").is_file()
+
+            # No need for explicit cleanup, the temporary directory will be deleted automatically
+
+
+def test_init_command_with_user_input():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with runner.isolated_filesystem(temp_dir=tmp_dir):
+            # Given
+            # Provide user inputs for the interactive prompts
+            user_inputs = "\n".join(
+                [
+                    "n",
+                    "y",
+                    "custom_value",
+                    "",
+                    "y",
+                    "",
+                    "n",
+                    "y",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "y",
+                    "json",
+                    "",
+                    "y",
+                    "y",
+                    "pipe",
+                    "n",
+                ]
+            )
+
+            result = runner.invoke(app, ["init"], input=user_inputs)
+            # Then
+            assert result.exit_code == 0
+            # Pay attention to the assertions if the user inputs are changed
+            assert Path("pyproject.toml").is_file()
+            parsed_toml = toml.loads(Path("pyproject.toml").read_text())
+            assert parsed_toml["tool"]["vertex_deployer"]["vertex_folder_path"] == "custom_value"
+            assert parsed_toml["tool"]["vertex_deployer"]["deploy"]["upload"] is True
+            assert parsed_toml["tool"]["vertex_deployer"]["deploy"]["compile"] is False
+            assert parsed_toml["tool"]["vertex_deployer"]["create"]["config_type"] == "json"
+            assert "env_file" not in parsed_toml["tool"]["vertex_deployer"]["deploy"]
+            assert "cron" not in parsed_toml["tool"]["vertex_deployer"]["deploy"]
+            assert "check" not in parsed_toml["tool"]["vertex_deployer"]
+
+            # No need for explicit cleanup, the temporary directory will be deleted automatically

--- a/tests/unit_tests/input_files/folder/template2.yaml.jinja
+++ b/tests/unit_tests/input_files/folder/template2.yaml.jinja
@@ -1,0 +1,1 @@
+This is the cloudbuild.yaml template.

--- a/tests/unit_tests/input_files/template1.txt.jinja
+++ b/tests/unit_tests/input_files/template1.txt.jinja
@@ -1,0 +1,1 @@
+My name is {{ name }} and I am {{ age }} years old.

--- a/tests/unit_tests/input_files/template3.env.jinja
+++ b/tests/unit_tests/input_files/template3.env.jinja
@@ -1,0 +1,1 @@
+This is the .env template file.

--- a/tests/unit_tests/test_init_deployer.py
+++ b/tests/unit_tests/test_init_deployer.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from deployer.constants import TEMPLATES_PATH_TESTS
+from deployer.init_deployer import _create_file_from_template, _generate_templates_mapping
+from deployer.utils.exceptions import TemplateFileCreationError
+
+
+class TestCreateFileFromTemplate:
+    def test_create_file_from_template_valid_inputs(self):
+        # Arrange
+        path = Path("tests/unit_tests/test_file.txt")
+        template_path = Path("tests/unit_tests/input_files/template1.txt.jinja")
+        kwargs = {"name": "John", "age": 30}
+
+        # Act
+        _create_file_from_template(path, template_path, **kwargs)
+
+        # Assert
+        assert path.exists()
+        assert path.read_text() == "My name is John and I am 30 years old."
+
+        # Cleanup
+        path.unlink()
+
+    def test_create_file_template_not_exist(self):
+        # Arrange
+        path = Path("tests/unit_tests/test_file.txt")
+        template_path = Path("tests/unit_tests/inputs_files/nonexistent_template.txt")
+        kwargs = {"name": "John", "age": 30}
+
+        # Act and Assert
+        with pytest.raises(TemplateFileCreationError):
+            _create_file_from_template(path, template_path, **kwargs)
+
+
+class TestGenerateTemplatesMapping:
+    def test_generate_templates_mapping_with_and_without_variables(self):
+        # Arrange
+        templates_dict = {
+            "template1": Path(TEMPLATES_PATH_TESTS / "template1.txt.jinja"),
+            "template2": Path(TEMPLATES_PATH_TESTS / "folder/template2.yaml.jinja"),
+            "template3": Path(TEMPLATES_PATH_TESTS / "template3.env.jinja"),
+        }
+        output_folder_path = Path("output")
+        mapping_variables = {
+            "name": "John",
+            "age": 30,
+        }
+
+        with patch("deployer.init_deployer.TEMPLATES_PATH", TEMPLATES_PATH_TESTS):
+            # Act
+            result = _generate_templates_mapping(
+                templates_dict, mapping_variables, output_folder_path
+            )
+
+            # Assert
+            assert len(result) == len(templates_dict)
+            for _, template_path in templates_dict.items():
+                output_path = output_folder_path / str(
+                    template_path.relative_to(TEMPLATES_PATH_TESTS)
+                ).replace(".jinja", "")
+                assert output_path in result
+                assert result[output_path][0].resolve() == template_path.resolve()
+                expected_variables = (
+                    mapping_variables if template_path == templates_dict["template1"] else {}
+                )
+                assert result[output_path][1] == expected_variables


### PR DESCRIPTION
## Description

This PR introduces new tests regarding the init command. Both unit and integration. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make format-code`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
