### PR TITLE
enh: rename pipeline UI

### DIFF
--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -227,6 +227,15 @@ def deploy(  # noqa: C901
             "Defaults to '{pipeline_name}-experiment'.",
         ),
     ] = None,
+    display_name: Annotated[
+        Optional[str],
+        typer.Option(
+            "--display-name",
+            "-dn",
+            help="The display name of the pipeline in Vertex."
+            "Defaults to '{pipeline_name}-%Y%m%d%H%M%S'.",
+        ),
+    ] = None,
     skip_validation: Annotated[
         bool,
         typer.Option(
@@ -276,6 +285,7 @@ def deploy(  # noqa: C901
             staging_bucket_name=vertex_settings.VERTEX_STAGING_BUCKET_NAME,
             service_account=vertex_settings.VERTEX_SERVICE_ACCOUNT,
             pipeline_name=pipeline_name,
+            ui_display_name=display_name,
             pipeline_func=pipeline_func,
             gar_location=vertex_settings.GAR_LOCATION,
             gar_repo_id=vertex_settings.GAR_PIPELINES_REPO_ID,

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -233,7 +233,7 @@ def deploy(  # noqa: C901
             "--display-name",
             "-dn",
             help="The display name of the pipeline in Vertex."
-            "Defaults to '{pipeline_name}-%Y%m%d%H%M%S'.",
+            "Defaults to '{pipeline_name}-{tags}-%Y%m%d%H%M%S'.",
         ),
     ] = None,
     skip_validation: Annotated[
@@ -285,7 +285,7 @@ def deploy(  # noqa: C901
             staging_bucket_name=vertex_settings.VERTEX_STAGING_BUCKET_NAME,
             service_account=vertex_settings.VERTEX_SERVICE_ACCOUNT,
             pipeline_name=pipeline_name,
-            ui_display_name=display_name,
+            pipeline_display_name=display_name,
             pipeline_func=pipeline_func,
             gar_location=vertex_settings.GAR_LOCATION,
             gar_repo_id=vertex_settings.GAR_PIPELINES_REPO_ID,

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -227,12 +227,12 @@ def deploy(  # noqa: C901
             "Defaults to '{pipeline_name}-experiment'.",
         ),
     ] = None,
-    display_name: Annotated[
+    run_name: Annotated[
         Optional[str],
         typer.Option(
-            "--display-name",
-            "-dn",
-            help="The display name of the pipeline in Vertex."
+            "--run-name",
+            "-rn",
+            help="The pipeline's run name. Displayed in the UI."
             "Defaults to '{pipeline_name}-{tags}-%Y%m%d%H%M%S'.",
         ),
     ] = None,
@@ -285,7 +285,7 @@ def deploy(  # noqa: C901
             staging_bucket_name=vertex_settings.VERTEX_STAGING_BUCKET_NAME,
             service_account=vertex_settings.VERTEX_SERVICE_ACCOUNT,
             pipeline_name=pipeline_name,
-            pipeline_display_name=display_name,
+            run_name=run_name,
             pipeline_func=pipeline_func,
             gar_location=vertex_settings.GAR_LOCATION,
             gar_repo_id=vertex_settings.GAR_PIPELINES_REPO_ID,

--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 TEMPLATES_PATH = Path(__file__).parent / "_templates"
@@ -64,3 +65,5 @@ INSTRUCTIONS = (
     "you can add the following flags to the deploy command if not set in your config:\n"
     "--schedule --cron=cron_expression --scheduler-timezone=IANA_time_zone\n"
 )
+
+_RUN_NAME_VALID_NAME_PATTERN = re.compile("^[a-z][-a-z0-9]{0,127}$", re.IGNORECASE)

--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -66,4 +66,4 @@ INSTRUCTIONS = (
     "--schedule --cron=cron_expression --scheduler-timezone=IANA_time_zone\n"
 )
 
-_RUN_NAME_VALID_NAME_PATTERN = re.compile("^[a-z][-a-z0-9]{0,127}$", re.IGNORECASE)
+VALID_RUN_NAME_PATTERN = re.compile("^[a-z][-a-z0-9]{0,127}$", re.IGNORECASE)

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -114,14 +114,13 @@ class VertexPipelineDeployer:
         """Each run name (job_id) must be unique.
         We thus always add a timestamp to ensure uniqueness.
         """
-        now_str = datetime.now().strftime("%Y%m%d%H%M%S")
+        now_str = datetime.now().strftime("%Y%m%d-%H%M%S")
         if self.run_name is None:
             self.run_name = f"{self.pipeline_name}"
             if tag:
                 self.run_name += f"-{tag}"
-        else:
-            self.run_name = self.run_name.replace("_", "-")
 
+        self.run_name = self.run_name.replace("_", "-")
         self.run_name += f"-{now_str}"
 
         if not constants.VALID_RUN_NAME_PATTERN.match(self.run_name):

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -124,10 +124,10 @@ class VertexPipelineDeployer:
 
         self.run_name += f"-{now_str}"
 
-        if not constants._RUN_NAME_VALID_NAME_PATTERN.match(self.run_name):
+        if not constants.VALID_RUN_NAME_PATTERN.match(self.run_name):
             raise ValueError(
                 f"Run name {self.run_name} does not match the pattern"
-                f" {constants._RUN_NAME_VALID_NAME_PATTERN.pattern}"
+                f" {constants.VALID_RUN_NAME_PATTERN.pattern}"
             )
         logger.debug(f"run_name is: {self.run_name}")
 

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -12,6 +12,7 @@ from kfp.registry import RegistryClient
 from loguru import logger
 from requests import HTTPError
 
+from deployer import constants
 from deployer.utils.exceptions import (
     MissingGoogleArtifactRegistryHostError,
     TagNotFoundError,
@@ -25,7 +26,7 @@ class VertexPipelineDeployer:
         self,
         pipeline_name: str,
         pipeline_func: Callable,
-        pipeline_display_name: Optional[str] = None,
+        run_name: Optional[str] = None,
         project_id: Optional[str] = None,
         region: Optional[str] = None,
         staging_bucket_name: Optional[str] = None,
@@ -41,7 +42,7 @@ class VertexPipelineDeployer:
         self.service_account = service_account
 
         self.pipeline_name = pipeline_name
-        self.pipeline_display_name = pipeline_display_name
+        self.run_name = run_name
         self.pipeline_func = pipeline_func
 
         self.gar_location = gar_location
@@ -109,20 +110,27 @@ class VertexPipelineDeployer:
 
         return experiment_name
 
-    def _check_pipeline_display_name(self, tag: Optional[str] = None) -> None:
+    def _check_run_name(self, tag: Optional[str] = None) -> None:
+        """Each run name (job_id) must be unique.
+        We thus always add a timestamp to ensure uniqueness.
+        """
         now_str = datetime.now().strftime("%Y%m%d%H%M%S")
+        if self.run_name is None:
+            self.run_name = f"{self.pipeline_name}"
+            if tag:
+                self.run_name += f"-{tag}"
 
-        if self.pipeline_display_name is None:
-            self.pipeline_display_name = f"{self.pipeline_name}"
-            logger.info(f"display_name not provided, using {self.pipeline_name} as base")
-        if tag:
-            self.pipeline_display_name += f"-{tag}"
-        self.pipeline_display_name += f"-{now_str}"
+        else:
+            self.run_name = self.run_name.replace("_", "-")
 
-        self.pipeline_display_name = self.pipeline_display_name.replace("_", "-")
-        self.pipeline_display_name = self.pipeline_display_name[:127]
+        self.run_name += f"-{now_str}"
 
-        logger.info(f"Pipeline_display_name is: {self.pipeline_display_name}")
+        if not constants._RUN_NAME_VALID_NAME_PATTERN.match(self.run_name):
+            raise ValueError(
+                f"Run name {self.run_name} does not match the pattern"
+                f" {constants._RUN_NAME_VALID_NAME_PATTERN.pattern}"
+            )
+        logger.debug(f"run_name is: {self.run_name}")
 
     def _create_pipeline_job(
         self,
@@ -157,7 +165,7 @@ class VertexPipelineDeployer:
         """  # noqa: E501
         job = aiplatform.PipelineJob(
             display_name=self.pipeline_name,
-            job_id=self.pipeline_display_name,
+            job_id=self.run_name,
             template_path=template_path,
             pipeline_root=self.staging_bucket_uri,
             location=self.region,
@@ -229,7 +237,7 @@ class VertexPipelineDeployer:
             tag (str, optional): Tag of the pipeline template. Defaults to None.
         """  # noqa: E501
         experiment_name = self._check_experiment_name(experiment_name)
-        self._check_pipeline_display_name(tag=tag)
+        self._check_run_name(tag=tag)
         template_path = self._get_template_path(tag)
 
         logger.debug(

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -23,6 +23,7 @@ class VertexPipelineDeployer:
     def __init__(
         self,
         pipeline_name: str,
+        ui_display_name: str,
         pipeline_func: Callable,
         project_id: Optional[str] = None,
         region: Optional[str] = None,
@@ -39,6 +40,7 @@ class VertexPipelineDeployer:
         self.service_account = service_account
 
         self.pipeline_name = pipeline_name
+        self.ui_display_name = ui_display_name
         self.pipeline_func = pipeline_func
 
         self.gar_location = gar_location
@@ -139,6 +141,7 @@ class VertexPipelineDeployer:
         """  # noqa: E501
         job = aiplatform.PipelineJob(
             display_name=self.pipeline_name,
+            job_id=self.ui_display_name,
             template_path=template_path,
             pipeline_root=self.staging_bucket_uri,
             location=self.region,

--- a/deployer/pipeline_deployer.py
+++ b/deployer/pipeline_deployer.py
@@ -119,7 +119,6 @@ class VertexPipelineDeployer:
             self.run_name = f"{self.pipeline_name}"
             if tag:
                 self.run_name += f"-{tag}"
-
         else:
             self.run_name = self.run_name.replace("_", "-")
 

--- a/deployer/settings.py
+++ b/deployer/settings.py
@@ -30,6 +30,7 @@ class _DeployerDeploySettings(CustomBaseModel):
     config_name: Optional[str] = None
     enable_caching: Optional[bool] = None
     experiment_name: Optional[str] = None
+    display_name: Optional[str] = None
     skip_validation: bool = True
 
 

--- a/deployer/settings.py
+++ b/deployer/settings.py
@@ -30,7 +30,7 @@ class _DeployerDeploySettings(CustomBaseModel):
     config_name: Optional[str] = None
     enable_caching: Optional[bool] = None
     experiment_name: Optional[str] = None
-    display_name: Optional[str] = None
+    run_name: Optional[str] = None
     skip_validation: bool = True
 
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -123,6 +123,7 @@ $ vertex-deployer deploy [OPTIONS] PIPELINE_NAMES...
 * `-cn, --config-name TEXT`: Name of the json/py file with parameter values and input artifacts to use when running the pipeline. It must be in the pipeline config dir. e.g. `config_dev.json` for `./vertex/configs/{pipeline-name}/config_dev.json`.
 * `-ec, --enable-caching / -nec, --no-cache`: Whether to turn on caching for the run.If this is not set, defaults to the compile time settings, which are True for alltasks by default, while users may specify different caching options for individualtasks. If this is set, the setting applies to all tasks in the pipeline.Overrides the compile time settings. Defaults to None.
 * `-en, --experiment-name TEXT`: The name of the experiment to run the pipeline in.Defaults to '{pipeline_name}-experiment'.
+* `-dn, --display-name TEXT`: The display name of the pipeline in Vertex.Defaults to '{pipeline_name}-%Y%m%d%H%M%S'.
 * `-y, --skip-validation / -n, --no-skip`: Whether to continue without user validation of the settings.  [default: skip-validation]
 * `--help`: Show this message and exit.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -123,7 +123,7 @@ $ vertex-deployer deploy [OPTIONS] PIPELINE_NAMES...
 * `-cn, --config-name TEXT`: Name of the json/py file with parameter values and input artifacts to use when running the pipeline. It must be in the pipeline config dir. e.g. `config_dev.json` for `./vertex/configs/{pipeline-name}/config_dev.json`.
 * `-ec, --enable-caching / -nec, --no-cache`: Whether to turn on caching for the run.If this is not set, defaults to the compile time settings, which are True for alltasks by default, while users may specify different caching options for individualtasks. If this is set, the setting applies to all tasks in the pipeline.Overrides the compile time settings. Defaults to None.
 * `-en, --experiment-name TEXT`: The name of the experiment to run the pipeline in.Defaults to '{pipeline_name}-experiment'.
-* `-dn, --display-name TEXT`: The display name of the pipeline in Vertex.Defaults to '{pipeline_name}-{tags}-%Y%m%d%H%M%S'.
+* `-rn, --run-name TEXT`: The pipeline's run name. Displayed in the UI.Defaults to '{pipeline_name}-{tags}-%Y%m%d%H%M%S'.
 * `-y, --skip-validation / -n, --no-skip`: Whether to continue without user validation of the settings.  [default: skip-validation]
 * `--help`: Show this message and exit.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -123,7 +123,7 @@ $ vertex-deployer deploy [OPTIONS] PIPELINE_NAMES...
 * `-cn, --config-name TEXT`: Name of the json/py file with parameter values and input artifacts to use when running the pipeline. It must be in the pipeline config dir. e.g. `config_dev.json` for `./vertex/configs/{pipeline-name}/config_dev.json`.
 * `-ec, --enable-caching / -nec, --no-cache`: Whether to turn on caching for the run.If this is not set, defaults to the compile time settings, which are True for alltasks by default, while users may specify different caching options for individualtasks. If this is set, the setting applies to all tasks in the pipeline.Overrides the compile time settings. Defaults to None.
 * `-en, --experiment-name TEXT`: The name of the experiment to run the pipeline in.Defaults to '{pipeline_name}-experiment'.
-* `-dn, --display-name TEXT`: The display name of the pipeline in Vertex.Defaults to '{pipeline_name}-%Y%m%d%H%M%S'.
+* `-dn, --display-name TEXT`: The display name of the pipeline in Vertex.Defaults to '{pipeline_name}-{tags}-%Y%m%d%H%M%S'.
 * `-y, --skip-validation / -n, --no-skip`: Whether to continue without user validation of the settings.  [default: skip-validation]
 * `--help`: Show this message and exit.
 

--- a/tests/integration_tests/test_init.py
+++ b/tests/integration_tests/test_init.py
@@ -60,6 +60,7 @@ def test_init_command_with_user_input(tmp_path):
                 "",
                 "",
                 "",
+                "",
                 "y",
                 "json",
                 "",


### PR DESCRIPTION
## Description

Branch which **adds the a CLI argument, to specify the pipeline's display name** on the Vertex UI.

The display name will always include:
- the first tag
- the date & time at which the pipeline was launched

By default, the name displayed in the UI is the pipeline's name.

```
vertex-deployer deploy dummy_pipeline \           
    --compile \
    --upload \
    --run \
    --env-file .env \
    --tags armand \
    --config-filepath vertex/configs/dummy_pipeline/config_test.json \
    --experiment-name my-experiment \
    --enable-caching \
    --skip-validation \
    --display-name test-pipeline
```

<img width="706" alt="image" src="https://github.com/artefactory/vertex-pipelines-deployer/assets/101176396/79717657-53cd-4ae8-a79b-374ef8ee4a85">

## Related Issue

#184 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
