### PR TITLE
enh: add yaml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,12 @@ def pipeline():
 
 #### Configs
 
-Config file can be either `.py`, `.json` or `.toml` files.
+Config file can be either `.py`, `.json`, `.toml` or `yaml` format.
 They must be located in the `config/{pipeline_name}` folder.
-
-!!! question "Why not YAML?"
-    YAML is not supported yet. Feel free to open a PR if you want to add it.
 
 **Why multiple formats?**
 
-`.py` files are useful to define complex configs (e.g. a list of dicts) while `.json` / `.toml` files are useful to define simple configs (e.g. a string).
+`.py` files are useful to define complex configs (e.g. a list of dicts) while `.json` / `.toml` / `yaml` files are useful to define simple configs (e.g. a string).
 It also adds flexibility to the user and allows you to use the deployer with almost no migration cost.
 
 **How to format them?**
@@ -262,20 +259,23 @@ It also adds flexibility to the user and allows you to use the deployer with alm
     Section names will be joined using `"_"` separator and this is not configurable at the moment.
     Example:
 
-=== "TOML file"
-    ```toml
-    [modeling]
-    model_name = "my-model"
-    params = { lambda = 0.1 }
-    ```
+    === "TOML file"
+        ```toml
+        [modeling]
+        model_name = "my-model"
+        params = { lambda = 0.1 }
+        ```
 
-=== "Resulting parameter values"
-    ```python
-    {
-        "modeling_model_name": "my-model",
-        "modeling_params": { "lambda": 0.1 }
-    }
-    ```
+    === "Resulting parameter values"
+        ```python
+        {
+            "modeling_model_name": "my-model",
+            "modeling_params": { "lambda": 0.1 }
+        }
+        ```
+
+- `.yaml` files must be valid yaml files containing only one dict of key: value representing parameter values.
+
 ??? question "Why are sections flattened when using TOML config files?"
     Vertex Pipelines parameter validation and parameter logging to Vertex Experiments are based on the parameter name.
     If you do not flatten your sections, you'll only be able to validate section names and that they should be of type `dict`.

--- a/deployer/utils/config.py
+++ b/deployer/utils/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import tomlkit.items
+import yaml
 from loguru import logger
 from pydantic import ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -83,6 +84,7 @@ class ConfigType(str, Enum):  # noqa: D101
     json = "json"
     py = "py"
     toml = "toml"
+    yaml = "yaml"
 
 
 def list_config_filepaths(configs_root_path: Path, pipeline_name: str) -> List[Path]:
@@ -131,6 +133,11 @@ def load_config(config_filepath: Path) -> Tuple[Optional[dict], Optional[dict]]:
 
     if config_filepath.suffix == ".toml":
         parameter_values = _load_config_toml(config_filepath)
+        return parameter_values, None
+
+    if config_filepath.suffix == ".yaml":
+        with open(config_filepath, "r") as f:
+            parameter_values = yaml.safe_load(f)
         return parameter_values, None
 
     if config_filepath.suffix == ".py":

--- a/deployer/utils/config.py
+++ b/deployer/utils/config.py
@@ -136,8 +136,7 @@ def load_config(config_filepath: Path) -> Tuple[Optional[dict], Optional[dict]]:
         return parameter_values, None
 
     if config_filepath.suffix == ".yaml":
-        with open(config_filepath, "r") as f:
-            parameter_values = yaml.safe_load(f)
+        parameter_values = _load_config_yaml(config_filepath)
         return parameter_values, None
 
     if config_filepath.suffix == ".py":
@@ -226,4 +225,23 @@ def _load_config_toml(config_filepath: Path) -> dict:
             f"{config_filepath}: invalid TOML config file.\n{e.__class__.__name__}: {e}"
         ) from e
 
+    return parameter_values
+
+
+def _load_config_yaml(config_filepath: Path) -> dict:
+    """Load the parameter values from a YAML config file.
+
+    Args:
+        config_filepath (Path): A `Path` object representing the path to the config file.
+
+    Returns:
+        dict: The loaded parameter values.
+    """
+    with open(config_filepath, "r") as f:
+        try:
+            parameter_values = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise BadConfigError(
+                f"{config_filepath}: invalid YAML config file.\n{e.__class__.__name__}: {e}"
+            ) from e
     return parameter_values

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -91,7 +91,7 @@ $ vertex-deployer create [OPTIONS] PIPELINE_NAMES...
 
 **Options**:
 
-* `-ct, --config-type [json|py|toml]`: The type of the config to create.  [default: py]
+* `-ct, --config-type [json|py|toml|yaml]`: The type of the config to create.  [default: py]
 * `--help`: Show this message and exit.
 
 ## `vertex-deployer deploy`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ The choice of format depends on the complexity and requirements of the configura
 Python files allow for complex configurations and dynamic values, while JSON and TOML files are more suitable for static and simple configurations.
 
 For example, you have here the same config file in the three formats:
+
 === "JSON"
     ```json title="vertex/configs/dummy_pipeline/config_test.json"
     {
@@ -76,6 +77,29 @@ For example, you have here the same config file in the three formats:
 
     Then, these sections are flattened, except for inline dicts, leading to slightly different parameter names
     (e.g., `modeling_grid_search_lambda` instead of `lambda`).
+
+
+=== "YAML"
+    ```yaml title="vertex/configs/dummy_pipeline/config_test.yaml"
+    model_name: my-model
+    default_params:
+      lambda: 0.1
+      alpha: hello world
+    grid_search:
+      lambda:
+        - 0.1
+        - 0.2
+        - 0.3
+      alpha:
+        - hello world
+        - goodbye world
+      cv: 3
+    ```
+
+    YAML config files are similar to TOML files in terms of flexibility and verbosity.
+
+    They are more human-readable than TOML files, but they are also more error-prone due to indentation.
+
 
 === "Python"
     ```python title="vertex/configs/dummy_pipeline/config_test.py"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,6 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.snippets
   - pymdownx.superfences
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
 


### PR DESCRIPTION
### **User description**
## Description

Add support for YAML config files

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make format-code`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for YAML configuration files in the `deployer/utils/config.py` module.
- Updated CLI documentation to reflect the addition of YAML as a supported configuration type.
- Included an example of a YAML configuration file in the documentation.
- Added `pymdownx.tabbed` extension with alternate style to the markdown configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add support for YAML configuration files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployer/utils/config.py
<li>Added support for YAML configuration files.<br> <li> Included YAML in the <code>ConfigType</code> enumeration.<br> <li> Implemented logic to load YAML configuration files.


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/193/files#diff-2c48e215d440aeecae9f090e613f56feaf379947ce68d01dc408039769e42d0a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLI_REFERENCE.md</strong><dd><code>Update CLI documentation to include YAML support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/CLI_REFERENCE.md
<li>Updated CLI documentation to include YAML as a supported config type.


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/193/files#diff-d86781a1877c689461dad5ee76b65aa1521793e50f753954721aa6d034605d4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configuration.md</strong><dd><code>Add YAML configuration file example and description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/configuration.md
<li>Added an example of a YAML configuration file.<br> <li> Described the human-readability and potential error-proneness of YAML <br>files.


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/193/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.yml</strong><dd><code>Add pymdownx.tabbed extension to markdown configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

mkdocs.yml
<li>Added <code>pymdownx.tabbed</code> extension with alternate style to markdown <br>extensions.


</details>
    

  </td>
  <td><a href="https://github.com/artefactory/vertex-pipelines-deployer/pull/193/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

