### PR TITLE
feat: add GitHub Actions and GitLab CI CD templates to init command

### DIFF
--- a/deployer/_templates/github-cd.yml.jinja
+++ b/deployer/_templates/github-cd.yml.jinja
@@ -1,0 +1,146 @@
+name: Vertex Pipelines CD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ${{ "{{" }} vars.GCP_PROJECT_ID {{ "}}" }}
+  GCP_REGION: ${{ "{{" }} vars.GCP_REGION {{ "}}" }}
+  GAR_LOCATION: ${{ "{{" }} vars.GAR_LOCATION {{ "}}" }}
+  GAR_DOCKER_REPO_ID: ${{ "{{" }} vars.GAR_DOCKER_REPO_ID {{ "}}" }}
+  GAR_PIPELINES_REPO_ID: ${{ "{{" }} vars.GAR_PIPELINES_REPO_ID {{ "}}" }}
+  GAR_VERTEX_BASE_IMAGE_NAME: ${{ "{{" }} vars.GAR_VERTEX_BASE_IMAGE_NAME {{ "}}" }}
+  VERTEX_STAGING_BUCKET_NAME: ${{ "{{" }} vars.VERTEX_STAGING_BUCKET_NAME {{ "}}" }}
+  VERTEX_SERVICE_ACCOUNT: ${{ "{{" }} vars.VERTEX_SERVICE_ACCOUNT {{ "}}" }}
+  TAG: ${{ "{{" }} github.sha {{ "}}" }}
+
+jobs:
+  build-base-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ "{{" }} vars.WIF_PROVIDER {{ "}}" }}
+          service_account: ${{ "{{" }} vars.WIF_SERVICE_ACCOUNT {{ "}}" }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GAR
+        run: gcloud auth configure-docker ${GAR_LOCATION}-docker.pkg.dev --quiet
+
+      - name: Build and push base image
+        run: |
+          IMAGE=${GAR_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${GAR_DOCKER_REPO_ID}/${GAR_VERTEX_BASE_IMAGE_NAME}:${TAG}
+          docker build \
+            -t ${IMAGE} \
+            -f {{ vertex_folder_path }}/deployment/Dockerfile \
+            --build-arg PROJECT_ID=${PROJECT_ID} \
+            --build-arg GCP_REGION=${GCP_REGION} \
+            --build-arg GAR_LOCATION=${GAR_LOCATION} \
+            --build-arg GAR_PIPELINES_REPO_ID=${GAR_PIPELINES_REPO_ID} \
+            --build-arg VERTEX_STAGING_BUCKET_NAME=${VERTEX_STAGING_BUCKET_NAME} \
+            --build-arg VERTEX_SERVICE_ACCOUNT=${VERTEX_SERVICE_ACCOUNT} \
+            .
+          docker push ${IMAGE}
+
+  check-pipelines:
+    runs-on: ubuntu-latest
+    needs: build-base-image
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install vertex-deployer
+
+      - name: Check all pipelines
+        run: vertex-deployer check --all
+
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: check-pipelines
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ "{{" }} vars.WIF_PROVIDER {{ "}}" }}
+          service_account: ${{ "{{" }} vars.WIF_SERVICE_ACCOUNT {{ "}}" }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install vertex-deployer
+
+      - name: Deploy pipelines to dev
+        run: vertex-deployer deploy --all --env-file deployer.env --tags dev
+
+  deploy-stg:
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    environment: stg
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ "{{" }} vars.WIF_PROVIDER {{ "}}" }}
+          service_account: ${{ "{{" }} vars.WIF_SERVICE_ACCOUNT {{ "}}" }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install vertex-deployer
+
+      - name: Deploy pipelines to stg
+        run: vertex-deployer deploy --all --env-file deployer.env --tags stg
+
+  deploy-prd:
+    runs-on: ubuntu-latest
+    needs: deploy-stg
+    environment: prd
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ "{{" }} vars.WIF_PROVIDER {{ "}}" }}
+          service_account: ${{ "{{" }} vars.WIF_SERVICE_ACCOUNT {{ "}}" }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install vertex-deployer
+
+      - name: Deploy pipelines to prd
+        run: vertex-deployer deploy --all --env-file deployer.env --tags prd

--- a/deployer/_templates/gitlab-ci.yml.jinja
+++ b/deployer/_templates/gitlab-ci.yml.jinja
@@ -1,0 +1,86 @@
+stages:
+  - build
+  - check
+  - deploy-dev
+  - deploy-stg
+  - deploy-prd
+
+variables:
+  GAR_IMAGE_PATH: "${GAR_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${GAR_DOCKER_REPO_ID}/${GAR_VERTEX_BASE_IMAGE_NAME}:${CI_COMMIT_SHA}"
+
+build-base-image:
+  stage: build
+  image: docker:latest
+  services:
+    - docker:dind
+  before_script:
+    - echo ${GCP_SA_KEY} | docker login -u _json_key --password-stdin https://${GAR_LOCATION}-docker.pkg.dev
+  script:
+    - >
+      docker build
+      -t ${GAR_IMAGE_PATH}
+      -f {{ vertex_folder_path }}/deployment/Dockerfile
+      --build-arg PROJECT_ID=${PROJECT_ID}
+      --build-arg GCP_REGION=${GCP_REGION}
+      --build-arg GAR_LOCATION=${GAR_LOCATION}
+      --build-arg GAR_PIPELINES_REPO_ID=${GAR_PIPELINES_REPO_ID}
+      --build-arg VERTEX_STAGING_BUCKET_NAME=${VERTEX_STAGING_BUCKET_NAME}
+      --build-arg VERTEX_SERVICE_ACCOUNT=${VERTEX_SERVICE_ACCOUNT}
+      .
+    - docker push ${GAR_IMAGE_PATH}
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+check-pipelines:
+  stage: check
+  image: python:3.10-slim
+  needs:
+    - build-base-image
+  script:
+    - pip install vertex-deployer
+    - vertex-deployer check --all
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+deploy-dev:
+  stage: deploy-dev
+  image: python:3.10-slim
+  needs:
+    - check-pipelines
+  before_script:
+    - pip install vertex-deployer
+  script:
+    - vertex-deployer deploy --all --env-file deployer.env --tags dev
+  environment:
+    name: dev
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+deploy-stg:
+  stage: deploy-stg
+  image: python:3.10-slim
+  needs:
+    - deploy-dev
+  before_script:
+    - pip install vertex-deployer
+  script:
+    - vertex-deployer deploy --all --env-file deployer.env --tags stg
+  environment:
+    name: stg
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+deploy-prd:
+  stage: deploy-prd
+  image: python:3.10-slim
+  needs:
+    - deploy-stg
+  before_script:
+    - pip install vertex-deployer
+  script:
+    - vertex-deployer deploy --all --env-file deployer.env --tags prd
+  environment:
+    name: prd
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  when: manual

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -16,8 +16,8 @@ from deployer.init_deployer import (
     _create_file_from_template,
     build_default_folder_structure,
     configure_deployer,
-    create_ci_cd_template,
     ensure_pyproject_toml,
+    prompt_ci_cd,
     show_commands,
 )
 from deployer.settings import (
@@ -566,18 +566,6 @@ def _prompt_create_pipeline(ctx: typer.Context):
             wrong_name = False
 
 
-def _prompt_ci_cd(vertex_folder_path: Path):
-    """Prompt the user to select a CI/CD platform and create the template."""
-    ci_cd_choices = set(constants.CICDProvider.__members__.values())
-    ci_cd_provider = Prompt.ask(
-        "Which CI/CD platform do you want to use?",
-        choices=ci_cd_choices,
-        default=constants.CICDProvider.none,
-    )
-    if ci_cd_provider != constants.CICDProvider.none:
-        create_ci_cd_template(ci_cd_provider, vertex_folder_path)
-
-
 @app.command(name="init")
 def init_deployer(
     ctx: typer.Context,
@@ -603,7 +591,7 @@ def init_deployer(
         create_pipeline(ctx, pipeline_names=["dummy_pipeline"])
 
         if not default:
-            _prompt_ci_cd(deployer_settings.vertex_folder_path)
+            prompt_ci_cd(deployer_settings)
 
         console.print("Default initialization done :sparkles:\n", style="bold blue")
         console.print("Here are some commands on how to use the deployer:", style="blue")
@@ -621,7 +609,7 @@ def init_deployer(
         if Confirm.ask("Do you want to create a pipeline?"):
             _prompt_create_pipeline(ctx)
 
-        _prompt_ci_cd(deployer_settings.vertex_folder_path)
+        prompt_ci_cd(deployer_settings)
 
         console.print("All done :sparkles:\n", style="bold blue")
 

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -16,6 +16,7 @@ from deployer.init_deployer import (
     _create_file_from_template,
     build_default_folder_structure,
     configure_deployer,
+    create_ci_cd_template,
     ensure_pyproject_toml,
     show_commands,
 )
@@ -542,6 +543,41 @@ def create_pipeline(
         )
 
 
+def _prompt_create_pipeline(ctx: typer.Context):
+    """Prompt the user to create a pipeline interactively."""
+    wrong_name = True
+    while wrong_name:
+        pipeline_name = Prompt.ask("What is the name of the pipeline?")
+
+        try:
+            config_type = Prompt.ask(
+                "What is the type of the config file?",
+                choices=set(ConfigType.__members__.values()),
+            )
+            create_pipeline(ctx, pipeline_names=[pipeline_name], config_type=config_type)
+        except typer.BadParameter as e:
+            console.print(e, style="red")
+        except FileExistsError:
+            console.print(
+                f"Pipeline '{pipeline_name}' already exists. Skipping creation.",
+                style="yellow",
+            )
+        else:
+            wrong_name = False
+
+
+def _prompt_ci_cd(vertex_folder_path: Path):
+    """Prompt the user to select a CI/CD platform and create the template."""
+    ci_cd_choices = set(constants.CICDProvider.__members__.values())
+    ci_cd_provider = Prompt.ask(
+        "Which CI/CD platform do you want to use?",
+        choices=ci_cd_choices,
+        default=constants.CICDProvider.none,
+    )
+    if ci_cd_provider != constants.CICDProvider.none:
+        create_ci_cd_template(ci_cd_provider, vertex_folder_path)
+
+
 @app.command(name="init")
 def init_deployer(
     ctx: typer.Context,
@@ -566,6 +602,9 @@ def init_deployer(
         build_default_folder_structure(deployer_settings)
         create_pipeline(ctx, pipeline_names=["dummy_pipeline"])
 
+        if not default:
+            _prompt_ci_cd(deployer_settings.vertex_folder_path)
+
         console.print("Default initialization done :sparkles:\n", style="bold blue")
         console.print("Here are some commands on how to use the deployer:", style="blue")
         show_commands(deployer_settings)
@@ -580,30 +619,14 @@ def init_deployer(
             build_default_folder_structure(deployer_settings)
 
         if Confirm.ask("Do you want to create a pipeline?"):
-            wrong_name = True
-            while wrong_name:
-                pipeline_name = Prompt.ask("What is the name of the pipeline?")
+            _prompt_create_pipeline(ctx)
 
-                try:
-                    config_type = Prompt.ask(
-                        "What is the type of the config file?",
-                        choices=set(ConfigType.__members__.values()),
-                    )
-                    create_pipeline(ctx, pipeline_names=[pipeline_name], config_type=config_type)
-                except typer.BadParameter as e:
-                    console.print(e, style="red")
-                except FileExistsError:
-                    console.print(
-                        f"Pipeline '{pipeline_name}' already exists. Skipping creation.",
-                        style="yellow",
-                    )
-                else:
-                    wrong_name = False
+        _prompt_ci_cd(deployer_settings.vertex_folder_path)
 
-            console.print("All done :sparkles:\n", style="bold blue")
+        console.print("All done :sparkles:\n", style="bold blue")
 
-            if Confirm.ask("Do you want to see some instructions on how to use the deployer"):
-                show_commands(deployer_settings)
+        if Confirm.ask("Do you want to see some instructions on how to use the deployer"):
+            show_commands(deployer_settings)
 
 
 @app.command(name="config")

--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -33,6 +33,17 @@ TEMPLATES_DEFAULT_STRUCTURE = {
     "build_base_image": Path(TEMPLATES_PATH / "deployment/build_base_image.sh.jinja"),
 }
 
+TEMPLATES_CI_CD = {
+    "github": {
+        "template": Path(TEMPLATES_PATH / "github-cd.yml.jinja"),
+        "output": Path(".github/workflows/cd.yml"),
+    },
+    "gitlab": {
+        "template": Path(TEMPLATES_PATH / "gitlab-ci.yml.jinja"),
+        "output": Path(".gitlab-ci.yml"),
+    },
+}
+
 INSTRUCTIONS = (
     "\n"
     "Now that your deployer is configured, make sure that you're also done with the setup!\n"
@@ -60,21 +71,10 @@ INSTRUCTIONS = (
 VALID_RUN_NAME_PATTERN = re.compile("^[a-z][-a-z0-9]{0,127}$", re.IGNORECASE)
 
 
-TEMPLATES_CI_CD = {
-    "github": Path(TEMPLATES_PATH / "github-cd.yml.jinja"),
-    "gitlab": Path(TEMPLATES_PATH / "gitlab-ci.yml.jinja"),
-}
-
-CI_CD_OUTPUT_PATHS = {
-    "github": Path(".github/workflows/cd.yml"),
-    "gitlab": Path(".gitlab-ci.yml"),
-}
-
-
 class CICDProvider(str, Enum):  # noqa: D101
     github = "github"
     gitlab = "gitlab"
-    none = "none"
+    skip = "none"
 
 
 class ConfigType(str, Enum):  # noqa: D101

--- a/deployer/constants.py
+++ b/deployer/constants.py
@@ -60,6 +60,23 @@ INSTRUCTIONS = (
 VALID_RUN_NAME_PATTERN = re.compile("^[a-z][-a-z0-9]{0,127}$", re.IGNORECASE)
 
 
+TEMPLATES_CI_CD = {
+    "github": Path(TEMPLATES_PATH / "github-cd.yml.jinja"),
+    "gitlab": Path(TEMPLATES_PATH / "gitlab-ci.yml.jinja"),
+}
+
+CI_CD_OUTPUT_PATHS = {
+    "github": Path(".github/workflows/cd.yml"),
+    "gitlab": Path(".gitlab-ci.yml"),
+}
+
+
+class CICDProvider(str, Enum):  # noqa: D101
+    github = "github"
+    gitlab = "gitlab"
+    none = "none"
+
+
 class ConfigType(str, Enum):  # noqa: D101
     json = "json"
     py = "py"

--- a/deployer/init_deployer.py
+++ b/deployer/init_deployer.py
@@ -2,15 +2,16 @@ from pathlib import Path
 
 import jinja2
 from jinja2 import Environment, FileSystemLoader, meta
+from rich.prompt import Prompt
 from rich.tree import Tree
 
 from deployer.__init__ import __version__ as deployer_version
 from deployer.constants import (
-    CI_CD_OUTPUT_PATHS,
     INSTRUCTIONS,
     TEMPLATES_CI_CD,
     TEMPLATES_DEFAULT_STRUCTURE,
     TEMPLATES_PATH,
+    CICDProvider,
 )
 from deployer.settings import (
     DeployerSettings,
@@ -176,17 +177,37 @@ def generate_tree(vertex_folder_path: Path):
     return root
 
 
-def create_ci_cd_template(provider: str, vertex_folder_path: Path):
+def _create_ci_cd_template(provider: str, mapping_variables: dict):
     """Create a CI/CD template file for the given provider."""
-    template_path = TEMPLATES_CI_CD[provider]
-    output_path = CI_CD_OUTPUT_PATHS[provider]
+    ci_cd_config = TEMPLATES_CI_CD[provider]
+    template_path = ci_cd_config["template"]
+    output_path = ci_cd_config["output"]
+
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_PATH)), autoescape=True)
+    template_name = str(template_path.relative_to(TEMPLATES_PATH))
+    template_source = env.loader.get_source(env, template_name)[0]
+    parsed_content = env.parse(template_source)
+    variables = meta.find_undeclared_variables(parsed_content)
+    template_variables = {var: mapping_variables[var] for var in variables}
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    _create_file_from_template(
-        output_path,
-        template_path,
-        vertex_folder_path=vertex_folder_path,
-    )
+    _create_file_from_template(output_path, template_path, **template_variables)
     console.print(f" CI/CD template created at '{output_path}' :sparkles:", style="bold blue")
+
+
+def prompt_ci_cd(deployer_settings: DeployerSettings):
+    """Prompt the user to select a CI/CD platform and create the template."""
+    ci_cd_choices = set(CICDProvider.__members__.values())
+    ci_cd_provider = Prompt.ask(
+        "Which CI/CD platform do you want to use?",
+        choices=ci_cd_choices,
+        default=CICDProvider.skip,
+    )
+    if ci_cd_provider != CICDProvider.skip:
+        mapping_variables = {
+            "vertex_folder_path": deployer_settings.vertex_folder_path,
+        }
+        _create_ci_cd_template(ci_cd_provider, mapping_variables)
 
 
 def show_commands(deployer_settings: DeployerSettings):

--- a/deployer/init_deployer.py
+++ b/deployer/init_deployer.py
@@ -5,7 +5,13 @@ from jinja2 import Environment, FileSystemLoader, meta
 from rich.tree import Tree
 
 from deployer.__init__ import __version__ as deployer_version
-from deployer.constants import INSTRUCTIONS, TEMPLATES_DEFAULT_STRUCTURE, TEMPLATES_PATH
+from deployer.constants import (
+    CI_CD_OUTPUT_PATHS,
+    INSTRUCTIONS,
+    TEMPLATES_CI_CD,
+    TEMPLATES_DEFAULT_STRUCTURE,
+    TEMPLATES_PATH,
+)
 from deployer.settings import (
     DeployerSettings,
     find_pyproject_toml,
@@ -168,6 +174,19 @@ def generate_tree(vertex_folder_path: Path):
     root.add("requirements-vertex.txt")
     root.add("pyproject.toml")
     return root
+
+
+def create_ci_cd_template(provider: str, vertex_folder_path: Path):
+    """Create a CI/CD template file for the given provider."""
+    template_path = TEMPLATES_CI_CD[provider]
+    output_path = CI_CD_OUTPUT_PATHS[provider]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    _create_file_from_template(
+        output_path,
+        template_path,
+        vertex_folder_path=vertex_folder_path,
+    )
+    console.print(f" CI/CD template created at '{output_path}' :sparkles:", style="bold blue")
 
 
 def show_commands(deployer_settings: DeployerSettings):

--- a/deployer/init_deployer.py
+++ b/deployer/init_deployer.py
@@ -197,13 +197,13 @@ def _create_ci_cd_template(provider: str, mapping_variables: dict):
 
 def prompt_ci_cd(deployer_settings: DeployerSettings):
     """Prompt the user to select a CI/CD platform and create the template."""
-    ci_cd_choices = set(CICDProvider.__members__.values())
+    ci_cd_choices = [p.value for p in CICDProvider]
     ci_cd_provider = Prompt.ask(
         "Which CI/CD platform do you want to use?",
         choices=ci_cd_choices,
-        default=CICDProvider.skip,
+        default=CICDProvider.skip.value,
     )
-    if ci_cd_provider != CICDProvider.skip:
+    if ci_cd_provider != CICDProvider.skip.value:
         mapping_variables = {
             "vertex_folder_path": deployer_settings.vertex_folder_path,
         }

--- a/tests/integration_tests/test_init.py
+++ b/tests/integration_tests/test_init.py
@@ -104,7 +104,6 @@ def test_init_command_with_user_input(tmp_path):
 
 def test_init_with_github_ci_cd(tmp_path):
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # "y" for quick setup, "github" for CI/CD
         result = runner.invoke(app, ["init"], input="y\ngithub\n", catch_exceptions=False)
 
         assert result.exit_code == 0
@@ -115,12 +114,12 @@ def test_init_with_github_ci_cd(tmp_path):
         assert "deploy-dev" in content
         assert "deploy-stg" in content
         assert "deploy-prd" in content
-        assert "vertex/" in content
+        assert "vertex/deployment/Dockerfile" in content
+        assert "{{ vertex_folder_path }}" not in content
 
 
 def test_init_with_gitlab_ci_cd(tmp_path):
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # "y" for quick setup, "gitlab" for CI/CD
         result = runner.invoke(app, ["init"], input="y\ngitlab\n", catch_exceptions=False)
 
         assert result.exit_code == 0
@@ -130,12 +129,12 @@ def test_init_with_gitlab_ci_cd(tmp_path):
         assert "deploy-dev" in content
         assert "deploy-stg" in content
         assert "deploy-prd" in content
-        assert "vertex/" in content
+        assert "vertex/deployment/Dockerfile" in content
+        assert "{{ vertex_folder_path }}" not in content
 
 
 def test_init_with_no_ci_cd(tmp_path):
     with runner.isolated_filesystem(temp_dir=tmp_path):
-        # "y" for quick setup, "none" for CI/CD
         result = runner.invoke(app, ["init"], input="y\nnone\n", catch_exceptions=False)
 
         assert result.exit_code == 0

--- a/tests/integration_tests/test_init.py
+++ b/tests/integration_tests/test_init.py
@@ -68,6 +68,7 @@ def test_init_command_with_user_input(tmp_path):
                 "y",
                 "pipe",
                 "json",
+                "none",
                 "n",
             ]
         )
@@ -99,3 +100,44 @@ def test_init_command_with_user_input(tmp_path):
         assert (Path("custom_value") / "lib").is_dir()
         assert (Path("custom_value") / "components").is_dir()
         assert (Path("custom_value") / "components" / "dummy_component.py").is_file()
+
+
+def test_init_with_github_ci_cd(tmp_path):
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # "y" for quick setup, "github" for CI/CD
+        result = runner.invoke(app, ["init"], input="y\ngithub\n", catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert Path(".github/workflows/cd.yml").is_file()
+        content = Path(".github/workflows/cd.yml").read_text()
+        assert "Vertex Pipelines CD" in content
+        assert "build-base-image" in content
+        assert "deploy-dev" in content
+        assert "deploy-stg" in content
+        assert "deploy-prd" in content
+        assert "vertex/" in content
+
+
+def test_init_with_gitlab_ci_cd(tmp_path):
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # "y" for quick setup, "gitlab" for CI/CD
+        result = runner.invoke(app, ["init"], input="y\ngitlab\n", catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert Path(".gitlab-ci.yml").is_file()
+        content = Path(".gitlab-ci.yml").read_text()
+        assert "build-base-image" in content
+        assert "deploy-dev" in content
+        assert "deploy-stg" in content
+        assert "deploy-prd" in content
+        assert "vertex/" in content
+
+
+def test_init_with_no_ci_cd(tmp_path):
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # "y" for quick setup, "none" for CI/CD
+        result = runner.invoke(app, ["init"], input="y\nnone\n", catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert not Path(".github/workflows/cd.yml").exists()
+        assert not Path(".gitlab-ci.yml").exists()


### PR DESCRIPTION
## Description

Add CI/CD workflow templates that users can generate during `vertex-deployer init`. When running the init command (in interactive mode), users are prompted to choose their CI/CD platform: GitHub Actions, GitLab CI, or none. The selected template is rendered and placed at the standard CI path (`.github/workflows/cd.yml` or `.gitlab-ci.yml`).

Both templates include a full pipeline with environment stages:
- **Build**: Build and push the base Docker image to Google Artifact Registry
- **Check**: Run `vertex-deployer check --all` to validate all pipelines
- **Deploy dev → stg → prd**: Sequential deployment through environments

The `--default` flag skips the CI/CD prompt entirely (no template generated).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] ⚙️ CI / CD update
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.