### PR TITLE
enh: use underscore instead of dash in cron parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.10
 default_stages: [commit, push]
 
 repos:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PYTHON_VERSION = 3.10
 .PHONY: download-poetry
 ## Download poetry
 download-poetry:
-	curl -sSL https://install.python-poetry.org | python3 -
+	curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
 
 
 .PHONY: install

--- a/deployer/cli.py
+++ b/deployer/cli.py
@@ -163,7 +163,7 @@ def deploy(  # noqa: C901
         Optional[str],
         typer.Option(
             help="Cron expression for scheduling the pipeline."
-            " To pass it to the CLI, use hyphens e.g. '0-10-*-*-*'."
+            " To pass it to the CLI, use underscore e.g. '0_10_*_*_*'."
         ),
     ] = None,
     delete_last_schedule: Annotated[
@@ -319,7 +319,7 @@ def deploy(  # noqa: C901
 
         if schedule:
             with console.status("Scheduling pipeline..."):
-                cron = cron.replace("-", " ")  # ugly fix to allow cron expression as env variable
+                cron = cron.replace("_", " ")  # ugly fix to allow cron expression as env variable
                 deployer.schedule(
                     cron=cron,
                     enable_caching=enable_caching,

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ $ vertex-deployer deploy [OPTIONS] PIPELINE_NAMES...
 * `-u, --upload / -nu, --no-upload`: Whether to upload the pipeline to Google Artifact Registry.  [default: no-upload]
 * `-r, --run / -nr, --no-run`: Whether to run the pipeline.  [default: no-run]
 * `-s, --schedule / -ns, --no-schedule`: Whether to create a schedule for the pipeline.  [default: no-schedule]
-* `--cron TEXT`: Cron expression for scheduling the pipeline. To pass it to the CLI, use hyphens e.g. '0-10-*-*-*'.
+* `--cron TEXT`: Cron expression for scheduling the pipeline. To pass it to the CLI, use underscore e.g. '0_10_*_*_*'.
 * `-dls, --delete-last-schedule`: Whether to delete the previous schedule before creating a new one.
 * `--scheduler-timezone TEXT`: Timezone for scheduling the pipeline. Must be a valid string from IANA time zone database  [default: Europe/Paris]
 * `--tags TEXT`: The tags to use when uploading the pipeline.


### PR DESCRIPTION
## Description

Use underscore instead of dash in cron parsing because dash can be part of cron syntax.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] ⚙️ CI / CD update
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
