### PR TITLE
docs: add CLAUDE.md and remove redundant ruff isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,6 @@ repos:
     - id: check-added-large-files
   - repo: local
     hooks:
-    - id: ruff-isort
-      name: ruff isort
-      entry: uv run ruff check --fix --select I --config pyproject.toml --show-fixes
-      types: [python]
-      language: system
-      stages: [commit, push]
     - id: ruff-format
       name: ruff format
       entry: uv run ruff format --config pyproject.toml
@@ -26,7 +20,7 @@ repos:
       stages: [commit, push]
     - id: ruff-check
       name: ruff check
-      entry: uv run ruff check --config pyproject.toml --output-format concise
+      entry: uv run ruff check --fix --config pyproject.toml --output-format concise
       types: [python]
       language: system
       stages: [commit, push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Project overview
+
+Vertex Pipelines Deployer (`vertex-deployer`) is a CLI tool to check, compile, upload, run, and schedule Kubeflow Pipelines on GCP Vertex AI. It's a Python library (3.10–3.13) using Typer for the CLI, Pydantic for settings, and kfp/google-cloud-aiplatform for pipeline management.
+
+## Development setup
+
+```bash
+make install              # Create venv, sync all deps, install pre-commit hooks
+make install-dev-requirements  # Dev deps only (pytest, ruff, pre-commit, etc.)
+```
+
+Package manager: **uv** (not pip/poetry). `uv.lock` is not committed (this is a library).
+
+## Common commands
+
+```bash
+make run-unit-tests        # pytest tests/unit_tests with coverage
+make run-integration-tests # pytest tests/integration_tests
+make run-tests             # Both
+make format-code           # Run all pre-commit hooks (ruff, codespell, nbstripout)
+```
+
+## Code style
+
+- **Formatter/linter**: ruff (configured in pyproject.toml) — handles formatting, isort, linting
+- **Line length**: 99
+- **Docstrings**: Google convention
+- Pre-commit hooks run ruff format, ruff check (with `--fix`, handles isort), codespell, and nbstripout on commit and push
+- A push hook auto-generates CLI docs via `typer deployer/cli.py utils docs`
+
+## Project structure
+
+- `deployer/` — main package (CLI in `cli.py`, settings in `settings.py`, pipeline logic in `pipeline_deployer.py`)
+- `tests/unit_tests/` and `tests/integration_tests/` — test directories
+- `templates/` — project templates
+- `docs/` — mkdocs documentation
+
+## Git workflow
+
+- Branch from and merge PRs into **`develop`** (not `main`)
+- **Squash and merge only** to keep a linear and condensed git history
+- Branch names follow conventional commits: `type/short-description` (e.g. `feat/add-scheduling`, `fix/pipeline-timeout`, `docs/update-readme`)
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — allowed prefixes: `build`, `chore`, `ci`, `docs`, `enh`, `feat`, `fix`, `perf`, `style`, `refactor`, `test`
+- PR titles also follow conventional commits format
+- `feat` → minor bump, `build`/`enh`/`fix`/`perf` → patch bump
+- Releases: merge `develop` → `main`, which triggers semantic-release via GitHub Actions
+
+## Testing
+
+- Unit tests: `tests/unit_tests/` — run with `make run-unit-tests`
+- Integration tests: `tests/integration_tests/` — run with `make run-integration-tests`
+- Use pytest; coverage is tracked for the `deployer` package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ make format-code           # Run all pre-commit hooks (ruff, codespell, nbstripo
 - PR titles also follow conventional commits format
 - `feat` → minor bump, `build`/`enh`/`fix`/`perf` → patch bump
 - Releases: merge `develop` → `main`, which triggers semantic-release via GitHub Actions
+- Issues and PRs must use the provided templates (`.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/`)
+- PR template requires: description, related issue link, type of change checklist, and a contributor checklist (code formatted, tests written, docstrings in Google format, docs updated if needed)
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project context derived from contributing guidelines (dev setup, code style, git workflow, testing)
- Documents conventions: conventional commit branch names (`type/description`), squash-and-merge only, PR titles in conventional commits format
- Remove the separate `ruff-isort` pre-commit hook — `ruff check --fix` already handles isort via the `I` rule configured in `pyproject.toml`

## Test plan

- [ ] Verify `CLAUDE.md` content is accurate and consistent with existing docs
- [ ] Run `make format-code` to confirm pre-commit hooks still work without the separate isort hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)