### PR TITLE
docs: fix outdated references and add missing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ make install-dev-requirements
 
 ### Codestyle
 
-This projects uses [Black](https://black.readthedocs.io/en/stable/), isort, ruff for codestyle. You can run the following command to format your code. It uses Pre-commit hooks to run the formatters and linters.
+This project uses [ruff](https://docs.astral.sh/ruff/) for code formatting, linting, and import sorting. You can run the following command to format your code. It uses pre-commit hooks to run the formatters and linters.
 
 ```bash
 make format-code

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ update-requirements:
 
 
 .PHONY: format-code
-## Format/lint all-files using pre-commit hooks (black, flake8, isort, ...)
+## Format/lint all-files using pre-commit hooks (ruff, codespell, ...)
 format-code:
 	@uv run pre-commit run -a --hook-stage pre-push
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@
 [![CI](https://github.com/artefactory/vertex-pipelines-deployer/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/artefactory/vertex-pipelines-deployer/actions/workflows/ci.yaml)
 [![Release](https://github.com/artefactory/vertex-pipelines-deployer/actions/workflows/release.yaml/badge.svg?branch=main&event=push)](https://github.com/artefactory/vertex-pipelines-deployer/actions/workflows/release.yaml)
 
-[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-informational?logo=pre-commit&logoColor=white)](https://github.com/ornikar/vertex-eduscore/blob/develop/.pre-commit-config.yaml)
+[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-informational?logo=pre-commit&logoColor=white)](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/.pre-commit-config.yaml)
 [![Linting: ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat)](https://pycqa.github.io/isort/)
 
 </div>
 
@@ -86,7 +85,7 @@ Two main commands:
 <!-- --8<-- [start:prerequisites] -->
 
 - Unix-like environment (Linux, macOS, WSL, etc.)
-- Python 3.8 to 3.10
+- Python 3.10 to 3.13
 - Google Cloud SDK
 - A GCP project with Vertex Pipelines enabled
 <!-- --8<-- [end:prerequisites] -->
@@ -368,19 +367,32 @@ This will create a `my_new_pipeline.py` file in the `vertex/pipelines` folder an
 
 #### `init`
 
-To initialize the deployer with default settings and folder structure, use the `init` command:
+To initialize the deployer with default settings, folder structure, and CI/CD templates, use the `init` command:
 ```bash
 vertex-deployer init
 ```
+
+The interactive wizard walks you through:
+
+1. **Configure the deployer** — set `vertex_folder_path`, log level, and default command options in `pyproject.toml`
+2. **Build default folder structure** — scaffold `vertex/` with `pipelines/`, `configs/`, `components/`, `deployment/`, and `lib/`
+3. **Create a pipeline** — generate a starter pipeline file and config
+4. **Set up CI/CD** — generate a GitHub Actions (`.github/workflows/cd.yml`) or GitLab CI (`.gitlab-ci.yml`) workflow with multi-environment deployment (dev → stg → prd)
 
 ```bash
 $ vertex-deployer init
 Welcome to Vertex Deployer!
 This command will help you getting fired up.
 Do you want to configure the deployer? [y/n]: n
-Do you want to build default folder structure [y/n]: n
+Do you want to build default folder structure [y/n]: y
 Do you want to create a pipeline? [y/n]: n
+Which CI/CD platform do you want to use? (github/gitlab/none) [none]: github
 All done ✨
+```
+
+Use `--default` to skip all prompts and create the full structure instantly (without CI/CD templates):
+```bash
+vertex-deployer init --default
 ```
 
 #### `list`

--- a/docs/advanced/advanced_user_guide.md
+++ b/docs/advanced/advanced_user_guide.md
@@ -89,6 +89,27 @@ You can add a pre-commit hook checking your pipelines integrity using a local ho
 
 Once you have a valid pipeline, you want to deploy it on Vertex. To automate deployment when merging to `develop` or `main`, you have multiple options.
 
+### Quick start with `init`
+
+The fastest way to set up CI/CD is with the `init` command:
+
+```bash
+vertex-deployer init
+```
+
+When prompted, select **github** or **gitlab** as your CI/CD platform. This generates a ready-to-use workflow with multi-environment deployment stages (dev → stg → prd).
+
+- **GitHub Actions**: creates `.github/workflows/cd.yml` with Workload Identity Federation authentication
+- **GitLab CI**: creates `.gitlab-ci.yml` with Docker-in-Docker image builds and manual production deployment gate
+
+The generated templates include: base image build, pipeline validation, and deployment to three environments. You'll need to configure the required CI/CD variables in your platform (see the environment variables section in the generated file).
+
+For GitHub Actions, you'll need to set up [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) and configure the following GitHub repository variables: `GCP_PROJECT_ID`, `GCP_REGION`, `GAR_LOCATION`, `GAR_DOCKER_REPO_ID`, `GAR_PIPELINES_REPO_ID`, `GAR_VERTEX_BASE_IMAGE_NAME`, `VERTEX_STAGING_BUCKET_NAME`, `VERTEX_SERVICE_ACCOUNT`, `WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`.
+
+### Manual setup options
+
+If you prefer to set up CI/CD manually, you have multiple options:
+
 - [use CloudBuild and CloudBuild triggers](#use-cloudbuild-trigger-preferred-option)
 - [use Github Action to trigger CloudBuild job](#github-action-cloudbuild)
 - [🚧 use Github Action only](#github-action-only)

--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -14,20 +14,62 @@ You can also override global deployer options such as logging level, or pipeline
 ```toml title="pyproject.toml"
 [tool.vertex_deployer]
 log-level = "INFO"
-pipelines-root-path = "./vertex/pipelines"
-config-root-path = "./configs"
+vertex-folder-path = "vertex"
 
 [tool.vertex_deployer.deploy]
-enable-cache = true
+enable-caching = true
 env-file = "example.env"
 compile = true
 upload = true
 run = true
 tags = ["my-tag"]
 experiment-name = "my-experiment"
-local-package-path = "."
 config-filepath = "vertex/configs/dummy_pipeline/config_test.json"
+scheduler-timezone = "Europe/Paris"
+
+[tool.vertex_deployer.check]
+all = false
+raise-error = false
+warn-defaults = true
+raise-for-defaults = false
+
+[tool.vertex_deployer.list]
+with-configs = false
+
+[tool.vertex_deployer.create]
+config-type = "yaml"
 ```
+
+### All configurable fields
+
+Below is the full reference of settings you can override in `pyproject.toml`:
+
+| Section | Field | Default | Description |
+|---|---|---|---|
+| *(root)* | `vertex-folder-path` | `"vertex"` | Root path for pipelines and configs |
+| *(root)* | `log-level` | `"INFO"` | Log level (`TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, `CRITICAL`) |
+| `deploy` | `env-file` | `None` | Path to the `.env` file |
+| `deploy` | `compile` | `true` | Compile the pipeline before deploying |
+| `deploy` | `upload` | `false` | Upload compiled pipeline to Artifact Registry |
+| `deploy` | `run` | `false` | Submit a pipeline run |
+| `deploy` | `schedule` | `false` | Create a pipeline schedule |
+| `deploy` | `cron` | `None` | Cron expression for scheduling |
+| `deploy` | `delete-last-schedule` | `false` | Delete previous schedule before creating new one |
+| `deploy` | `scheduler-timezone` | `"Europe/Paris"` | IANA timezone for scheduling |
+| `deploy` | `tags` | `None` | Tags for Artifact Registry upload |
+| `deploy` | `config-filepath` | `None` | Path to a specific config file |
+| `deploy` | `config-name` | `None` | Config filename (resolved from pipeline config dir) |
+| `deploy` | `enable-caching` | `None` | Enable/disable pipeline caching |
+| `deploy` | `experiment-name` | `None` | Vertex Experiment name |
+| `deploy` | `run-name` | `None` | Custom run display name |
+| `deploy` | `skip-validation` | `true` | Skip interactive settings confirmation |
+| `check` | `all` | `false` | Check all pipelines |
+| `check` | `config-filepath` | `None` | Path to a specific config file to check |
+| `check` | `raise-error` | `false` | Raise error if pipeline is invalid |
+| `check` | `warn-defaults` | `true` | Warn when default parameter values are used |
+| `check` | `raise-for-defaults` | `false` | Raise error when default values are used |
+| `list` | `with-configs` | `false` | Also list config files for each pipeline |
+| `create` | `config-type` | `"yaml"` | Default config file format (`json`, `py`, `toml`, `yaml`) |
 
 ## Pipelines config files
 
@@ -130,10 +172,11 @@ For example, you have here the same config file in the three formats:
 ## Vertex deployment settings
 
 The deployment settings are environment variables that configure the deployment environment for Vertex Pipelines.
-These variables include the GCP project ID, region, and other settings related to the Google Cloud resources used by Vertex Pipelines.
+These are loaded by the `deploy` command when it needs to interact with GCP resources.
 
-These settings can be specified in an `.env` file or exported as environment variables. An example `.env` file might look like this:
-```bash
+These settings can be specified in an `.env` file (passed via `--env-file`) or exported as shell environment variables. All variables are **required** — the deploy command will fail with a validation error if any are missing.
+
+```bash title="example.env"
 PROJECT_ID=your-gcp-project-id
 GCP_REGION=europe-west1
 GAR_LOCATION=europe-west1
@@ -142,4 +185,26 @@ VERTEX_STAGING_BUCKET_NAME=your-vertex-staging-bucket-name
 VERTEX_SERVICE_ACCOUNT=your-vertex-service-account
 ```
 
-It is important to ensure that these settings are correctly configured before deploying a pipeline, as they will affect where and how the pipeline is executed.
+### Environment variables reference
+
+| Variable | Example | Description |
+|---|---|---|
+| `PROJECT_ID` | `my-gcp-project` | GCP project ID where pipelines will run |
+| `GCP_REGION` | `europe-west1` | GCP region for Vertex AI pipeline execution |
+| `GAR_LOCATION` | `europe-west1` | Google Artifact Registry location (usually the same as `GCP_REGION`) |
+| `GAR_PIPELINES_REPO_ID` | `vertex-pipelines` | Artifact Registry repository ID (must be KFP format) |
+| `VERTEX_STAGING_BUCKET_NAME` | `my-staging-bucket` | GCS bucket name for pipeline staging, **without** the `gs://` prefix |
+| `VERTEX_SERVICE_ACCOUNT` | `my-sa@project.iam.gserviceaccount.com` | Full email of the service account used for pipeline execution |
+
+### How `.env` loading works
+
+The `--env-file` flag uses [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) to load variables from the file.
+Variables defined in the `.env` file **override** existing environment variables.
+No default value for `--env-file` is provided, so you must explicitly pass it — this prevents accidentally deploying to the wrong project.
+
+!!! tip "Multiple environments"
+    Use separate env files for each environment: `dev.env`, `stg.env`, `prd.env`. Then deploy with:
+    ```bash
+    vertex-deployer deploy my_pipeline --env-file dev.env --run
+    vertex-deployer deploy my_pipeline --env-file prd.env --schedule --cron "0_9_*_*_1-5"
+    ```

--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -205,6 +205,6 @@ No default value for `--env-file` is provided, so you must explicitly pass it â€
 !!! tip "Multiple environments"
     Use separate env files for each environment: `dev.env`, `stg.env`, `prd.env`. Then deploy with:
     ```bash
-    vertex-deployer deploy my_pipeline --env-file dev.env --run
-    vertex-deployer deploy my_pipeline --env-file prd.env --schedule --cron "0_9_*_*_1-5"
+    vertex-deployer deploy my_pipeline --env-file dev.env --run --config-name config_dev.json
+    vertex-deployer deploy my_pipeline --env-file prd.env --schedule --cron "0_9_*_*_1-5" --config-name config_prd.json
     ```

--- a/docs/advanced/python_api.md
+++ b/docs/advanced/python_api.md
@@ -5,6 +5,7 @@ While `vertex-deployer` is primarily a CLI tool, you can also use the `VertexPip
 ## Basic example
 
 ```python
+from pathlib import Path
 from deployer.pipeline_deployer import VertexPipelineDeployer
 from my_project.vertex.pipelines.my_pipeline import my_pipeline
 
@@ -17,6 +18,7 @@ deployer = VertexPipelineDeployer(
     service_account="my-sa@my-gcp-project.iam.gserviceaccount.com",
     gar_location="europe-west1",
     gar_repo_id="my-pipelines-repo",
+    local_package_path=Path("."),
 )
 
 # Compile, upload, and run in one call
@@ -97,6 +99,8 @@ Creates a recurring schedule for the pipeline on Vertex AI. See [Scheduling Pipe
 If you don't need Artifact Registry, omit `gar_location` and `gar_repo_id`. The deployer will use the locally compiled YAML file instead:
 
 ```python
+from pathlib import Path
+
 deployer = VertexPipelineDeployer(
     pipeline_name="my_pipeline",
     pipeline_func=my_pipeline,
@@ -104,6 +108,7 @@ deployer = VertexPipelineDeployer(
     region="europe-west1",
     staging_bucket_name="my-staging-bucket",
     service_account="my-sa@my-gcp-project.iam.gserviceaccount.com",
+    local_package_path=Path("."),
 )
 
 deployer.compile().run(parameter_values={"learning_rate": 0.01})

--- a/docs/advanced/python_api.md
+++ b/docs/advanced/python_api.md
@@ -1,0 +1,114 @@
+# Using the Python API
+
+While `vertex-deployer` is primarily a CLI tool, you can also use the `VertexPipelineDeployer` class directly in your Python code. This is useful for custom scripts, notebooks, or when you need more control over the deployment process.
+
+## Basic example
+
+```python
+from deployer.pipeline_deployer import VertexPipelineDeployer
+from my_project.vertex.pipelines.my_pipeline import my_pipeline
+
+deployer = VertexPipelineDeployer(
+    pipeline_name="my_pipeline",
+    pipeline_func=my_pipeline,
+    project_id="my-gcp-project",
+    region="europe-west1",
+    staging_bucket_name="my-staging-bucket",
+    service_account="my-sa@my-gcp-project.iam.gserviceaccount.com",
+    gar_location="europe-west1",
+    gar_repo_id="my-pipelines-repo",
+)
+
+# Compile, upload, and run in one call
+deployer.compile_upload_run(
+    enable_caching=True,
+    parameter_values={"learning_rate": 0.01, "epochs": 10},
+    tags=["latest"],
+)
+```
+
+## Constructor parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `pipeline_name` | `str` | Yes | Name of the pipeline (must match the `@kfp.dsl.pipeline` function name) |
+| `pipeline_func` | `Callable` | Yes | The kfp pipeline function decorated with `@kfp.dsl.pipeline` |
+| `run_name` | `str` | No | Custom run name displayed in the UI. Defaults to `{pipeline_name}-{tag}-{timestamp}` |
+| `project_id` | `str` | No | GCP project ID |
+| `region` | `str` | No | GCP region (e.g. `europe-west1`) |
+| `staging_bucket_name` | `str` | No | GCS bucket name for pipeline staging (without `gs://` prefix) |
+| `service_account` | `str` | No | Service account email for pipeline execution |
+| `gar_location` | `str` | No | Google Artifact Registry location |
+| `gar_repo_id` | `str` | No | Google Artifact Registry repository ID (KFP format) |
+| `local_package_path` | `Path` | No | Local directory for compiled pipeline YAML files |
+
+## Step-by-step usage
+
+Each method returns `self`, so you can chain calls:
+
+```python
+# Step by step
+deployer.compile()
+deployer.upload_to_registry(tags=["latest", "v1.0"])
+deployer.run(
+    enable_caching=True,
+    parameter_values={"model_name": "my-model"},
+    experiment_name="my-experiment",
+    tag="latest",
+)
+
+# Or chained
+deployer.compile().upload_to_registry(tags=["latest"]).run(
+    parameter_values={"model_name": "my-model"},
+    tag="latest",
+)
+```
+
+## Methods
+
+### `compile()`
+
+Compiles the pipeline function to a YAML file in the `local_package_path` directory using `kfp.compiler.Compiler`.
+
+### `upload_to_registry(tags=["latest"])`
+
+Uploads the compiled pipeline YAML to Google Artifact Registry. Requires `gar_location` and `gar_repo_id` to be set.
+
+### `run(enable_caching, parameter_values, input_artifacts, experiment_name, tag)`
+
+Submits a pipeline run to Vertex AI. The pipeline template is resolved from Artifact Registry if available, otherwise from the local compiled YAML.
+
+- `enable_caching`: `None` uses compile-time defaults. `True`/`False` overrides caching for all tasks.
+- `parameter_values`: Dict of pipeline parameter names to values.
+- `input_artifacts`: Dict of artifact parameter names to resource IDs (e.g. `{"vertex_model": "456"}`).
+- `experiment_name`: Groups runs under a Vertex Experiment. Defaults to `{pipeline_name}-experiment`.
+- `tag`: Tag of the uploaded pipeline version to use from Artifact Registry.
+
+### `compile_upload_run(enable_caching, parameter_values, experiment_name, tags)`
+
+Convenience method that calls `compile()`, optionally `upload_to_registry()`, and `run()` in sequence.
+
+### `schedule(cron, enable_caching, parameter_values, tag, delete_last_schedule, scheduler_timezone)`
+
+Creates a recurring schedule for the pipeline on Vertex AI. See [Scheduling Pipelines](scheduling.md) for details.
+
+## Running without Artifact Registry
+
+If you don't need Artifact Registry, omit `gar_location` and `gar_repo_id`. The deployer will use the locally compiled YAML file instead:
+
+```python
+deployer = VertexPipelineDeployer(
+    pipeline_name="my_pipeline",
+    pipeline_func=my_pipeline,
+    project_id="my-gcp-project",
+    region="europe-west1",
+    staging_bucket_name="my-staging-bucket",
+    service_account="my-sa@my-gcp-project.iam.gserviceaccount.com",
+)
+
+deployer.compile().run(parameter_values={"learning_rate": 0.01})
+```
+
+## Full API reference
+
+For the complete API reference with all method signatures, see the [auto-generated API docs](../api/vertex_deployer.md).

--- a/docs/advanced/scheduling.md
+++ b/docs/advanced/scheduling.md
@@ -1,0 +1,100 @@
+# Scheduling Pipelines
+
+Vertex Deployer supports creating recurring pipeline schedules on Vertex AI using cron expressions.
+
+## Basic usage
+
+To schedule a pipeline, use the `--schedule` flag with a `--cron` expression:
+
+```bash
+vertex-deployer deploy my_pipeline \
+    --compile \
+    --upload \
+    --schedule \
+    --cron "0_9_*_*_1-5" \
+    --env-file .env \
+    --tags latest
+```
+
+!!! note "Cron expression format"
+    Because the CLI uses spaces to separate arguments, **replace spaces with underscores** in your cron expression.
+    For example, `0 9 * * 1-5` becomes `0_9_*_*_1-5`.
+
+## Cron expression examples
+
+| Expression | Schedule |
+|---|---|
+| `0_9_*_*_*` | Every day at 9:00 AM |
+| `0_9_*_*_1-5` | Every weekday at 9:00 AM |
+| `0_0_1_*_*` | First day of every month at midnight |
+| `0_*/6_*_*_*` | Every 6 hours |
+| `30_14_*_*_1` | Every Monday at 2:30 PM |
+
+## Timezone
+
+By default, schedules use the `Europe/Paris` timezone. You can change this with `--scheduler-timezone`:
+
+```bash
+vertex-deployer deploy my_pipeline \
+    --schedule \
+    --cron "0_9_*_*_*" \
+    --scheduler-timezone "US/Eastern" \
+    --env-file .env
+```
+
+The timezone must be a valid [IANA time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) string (e.g. `Europe/London`, `America/New_York`, `Asia/Tokyo`).
+
+You can set a default timezone in `pyproject.toml` to avoid passing it every time:
+
+```toml title="pyproject.toml"
+[tool.vertex_deployer.deploy]
+scheduler-timezone = "US/Eastern"
+```
+
+## Replacing a previous schedule
+
+By default, creating a schedule does not remove previous schedules for the same pipeline. To delete the most recent existing schedule before creating a new one, use `--delete-last-schedule`:
+
+```bash
+vertex-deployer deploy my_pipeline \
+    --schedule \
+    --cron "0_9_*_*_*" \
+    --delete-last-schedule \
+    --env-file .env
+```
+
+!!! warning
+    Only the most recent schedule for the pipeline is deleted. If you have multiple schedules, you may need to clean up older ones manually in the GCP console.
+
+## Requirements
+
+Scheduling requires:
+
+- The pipeline to be uploaded to **Google Artifact Registry** (the `--upload` flag or a previously uploaded version with a `--tags` reference)
+- The `GAR_LOCATION` and `GAR_PIPELINES_REPO_ID` environment variables to be set
+- A valid `VERTEX_SERVICE_ACCOUNT` with the `aiplatform.user` role
+
+## Programmatic usage
+
+You can also schedule pipelines using the Python API:
+
+```python
+from deployer.pipeline_deployer import VertexPipelineDeployer
+
+deployer = VertexPipelineDeployer(
+    pipeline_name="my_pipeline",
+    pipeline_func=my_pipeline_func,
+    project_id="my-project",
+    region="europe-west1",
+    staging_bucket_name="my-staging-bucket",
+    service_account="my-sa@my-project.iam.gserviceaccount.com",
+    gar_location="europe-west1",
+    gar_repo_id="my-pipelines-repo",
+)
+
+deployer.compile().upload_to_registry(tags=["latest"]).schedule(
+    cron="0 9 * * 1-5",
+    enable_caching=True,
+    scheduler_timezone="Europe/Paris",
+)
+```

--- a/docs/advanced/scheduling.md
+++ b/docs/advanced/scheduling.md
@@ -13,6 +13,7 @@ vertex-deployer deploy my_pipeline \
     --schedule \
     --cron "0_9_*_*_1-5" \
     --env-file .env \
+    --config-name config.json \
     --tags latest
 ```
 
@@ -39,6 +40,7 @@ vertex-deployer deploy my_pipeline \
     --schedule \
     --cron "0_9_*_*_*" \
     --scheduler-timezone "US/Eastern" \
+    --config-name config.json \
     --env-file .env
 ```
 
@@ -60,6 +62,7 @@ vertex-deployer deploy my_pipeline \
     --schedule \
     --cron "0_9_*_*_*" \
     --delete-last-schedule \
+    --config-name config.json \
     --env-file .env
 ```
 
@@ -79,6 +82,7 @@ Scheduling requires:
 You can also schedule pipelines using the Python API:
 
 ```python
+from pathlib import Path
 from deployer.pipeline_deployer import VertexPipelineDeployer
 
 deployer = VertexPipelineDeployer(
@@ -90,6 +94,7 @@ deployer = VertexPipelineDeployer(
     service_account="my-sa@my-project.iam.gserviceaccount.com",
     gar_location="europe-west1",
     gar_repo_id="my-pipelines-repo",
+    local_package_path=Path("."),
 )
 
 deployer.compile().upload_to_registry(tags=["latest"]).schedule(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,6 @@
         --upload \
         --run \
         --env-file example.env \
-        --local-package-path . \
         --tags my-tag \
         --config-filepath vertex/configs/dummy_pipeline/config_test.json \
         --experiment-name my-experiment \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,9 @@ nav:
     - Basic Usage: usage.md
   - Advanced User Guide:
     - Vertex DevOps: advanced/advanced_user_guide.md
-    - Understand settings and configurations: advanced/configuration.md
+    - Scheduling Pipelines: advanced/scheduling.md
+    - Python API: advanced/python_api.md
+    - Settings & Configuration: advanced/configuration.md
   - CLI Reference: CLI_REFERENCE.md
   - API Documentation:
     - VertexPipelineDeployer: api/vertex_deployer.md


### PR DESCRIPTION
## Description

Fixes outdated documentation and adds missing guides for features that were undocumented.

**Fixes:**
- Python version requirement: "3.8 to 3.10" → "3.10 to 3.13" in README
- Pre-commit badge URL: was linking to `ornikar/vertex-eduscore` instead of `artefactory/vertex-pipelines-deployer`
- Removed stale isort badge (ruff handles imports now)
- Replaced Black/isort references with ruff in CONTRIBUTING.md and Makefile
- Removed invalid `--local-package-path` CLI flag from docs/usage.md TL;DR example (it's a settings property, not a CLI argument)

**New documentation:**
- **Scheduling guide** (`docs/advanced/scheduling.md`): cron expression examples, timezone configuration, `--delete-last-schedule` usage, and programmatic scheduling
- **Python API guide** (`docs/advanced/python_api.md`): constructor parameters, step-by-step and chained usage, method descriptions, running without Artifact Registry
- **CI/CD templates**: documented the `init` command's new GitHub Actions / GitLab CI template generation in both README and advanced user guide
- **Full configuration reference**: added all `pyproject.toml` configurable fields (`check`, `list`, `create` sections) with defaults
- **Environment variables reference**: expanded with a reference table, `.env` loading behavior explanation, and multi-environment tips

## Related Issue

N/A — discovered during documentation audit.

## Type of Change

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔐 Security fix
- [ ] ⚙️ CI / CD update
- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/artefactory/vertex-pipelines-deployer/blob/develop/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make format-code`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)